### PR TITLE
Update data init - also for non conditional resources

### DIFF
--- a/src/layouts/includes/scripts.hbs
+++ b/src/layouts/includes/scripts.hbs
@@ -13,6 +13,7 @@
 <script src="resources/js/helper.js"></script>
 <!--<script src="resources/js/handlebars.helper.js"></script>-->
 <!--<script src="resources/js/handlebars.templates.js"></script>-->
+<script src="resources/js/initElementScripts.js"></script>
 <script src="resources/js/main.js"></script>
 <!-- endbuild -->
 

--- a/src/resources/js/initElementScripts.js
+++ b/src/resources/js/initElementScripts.js
@@ -1,0 +1,14 @@
+(function ($, window, document, undefined) {
+	'use strict';
+
+	ffglobal.configuration.set('initElementFunctions', function () {
+		var $elementsWithDataInit = $('[data-init]');
+		$elementsWithDataInit.each(function() {
+			if ($(this).data('init')) {
+				var initFunction = eval($(this).attr('data-init')); // jshint ignore:line
+				initFunction($(this));
+			}
+		});
+	});
+
+})(jQuery, window, document);

--- a/src/resources/js/main.js
+++ b/src/resources/js/main.js
@@ -2,7 +2,6 @@
 	'use strict';
 
 	$(function () {
-		var $conditionalResources = $('[data-resources]');
 
 		// listen to resourcesReady event
 		$(window).one('resourcesReady', function() {
@@ -19,16 +18,7 @@
 
 		function init() {
 			ffglobal.configuration.get('initCore')();
-
-			// initialize components
-			// TODO: move this as a function to conditional loader and call it with an event like 'resourceLoader.init'
-			// TODO: make sure conditional loader things are iitialized AFTER all other inits in main.js (maybe a comment where to place your plugin inits is enough)
-			$conditionalResources.each(function() {
-				if ($(this).data('init')) {
-					var init = eval($(this).attr('data-init')); // jshint ignore:line
-					init($(this));
-				}
-			});
+			ffglobal.configuration.get('initElementFunctions')();
 		}
 
 	});
@@ -36,7 +26,5 @@
 	ffglobal.configuration.set('initCore', function () {
 
 	});
-
-	// $(window).load(function() {});
 
 })(jQuery, window, document);


### PR DESCRIPTION
Now it is also possible to use the data-init property without the data-resource property.

In addition to that I moved the init call to another file.
So now it is more obvious for the loading order:

```
ffglobal.configuration.get('initCore')();
ffglobal.configuration.get('initElementFunctions')();
```